### PR TITLE
Urls for tests

### DIFF
--- a/follow/tests.py
+++ b/follow/tests.py
@@ -10,6 +10,8 @@ register(User)
 register(Group)
 
 class FollowTest(TestCase):
+    urls = 'follow.urls'
+
     def setUp(self):
         
         self.lennon = User.objects.create(username='lennon')


### PR DESCRIPTION
Fix for failing tests in case a project doesn't have 'follow' view. In our project we use mostly use ulrs named 'namespace:name', so tests keep failing.
