### PR TITLE
compatibility for Django version>1.5

### DIFF
--- a/follow/urls.py
+++ b/follow/urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls.defaults import *
+from django import VERSION as DjangoVersion
+if float('%s.%s' % DjangoVersion[:2]) > 1.5:
+    from django.conf.urls import patterns, url
+else:
+    from django.conf.urls.defaults import *
+
 
 urlpatterns = patterns('',
     url(r'^toggle/(?P<app>[^\/]+)/(?P<model>[^\/]+)/(?P<id>\d+)/$', 'follow.views.toggle', name='toggle'),

--- a/follow/utils.py
+++ b/follow/utils.py
@@ -3,7 +3,7 @@ from django.db.models.fields.related import ManyToManyField, ForeignKey
 from follow.models import Follow
 from follow.registry import registry, model_map
 from django import VERSION as DjangoVersion
-if float('%s.%s' % DjangoVersion[:2]) > 1.7:
+if float('%s.%s' % DjangoVersion[:2]) >= 1.7:
     module_name = 'model_name'
 else:
     module_name = 'module_name'

--- a/follow/utils.py
+++ b/follow/utils.py
@@ -2,6 +2,11 @@ from django.core.urlresolvers import reverse
 from django.db.models.fields.related import ManyToManyField, ForeignKey
 from follow.models import Follow
 from follow.registry import registry, model_map
+from django import VERSION as DjangoVersion
+if float('%s.%s' % DjangoVersion[:2]) > 1.7:
+    module_name = 'model_name'
+else:
+    module_name = 'module_name'
 
 def get_followers_for_object(instance):
     return Follow.objects.get_follows(instance)
@@ -9,18 +14,18 @@ def get_followers_for_object(instance):
 def register(model, field_name=None, related_name=None, lookup_method_name='get_follows'):
     """
     This registers any model class to be follow-able.
-    
+
     """
     if model in registry:
         return
 
     registry.append(model)
-    
+
     if not field_name:
-        field_name = 'target_%s' % model._meta.module_name
-    
+        field_name = 'target_%s' % model._meta.__getattribute__(module_name)
+
     if not related_name:
-        related_name = 'follow_%s' % model._meta.module_name
+        related_name = 'follow_%s' % model._meta.__getattribute__(module_name)
     
     field = ForeignKey(model, related_name=related_name, null=True,
         blank=True, db_index=True)


### PR DESCRIPTION
removes usage of deprecated urls.defaults module when Django version > 1.5. Checks Django version so it remains backwards compatible. Successfully ran follow tests.
